### PR TITLE
On signature creation, tabs can be computed by backend

### DIFF
--- a/django_docusign/forms.py
+++ b/django_docusign/forms.py
@@ -1,0 +1,38 @@
+"""Forms and helpers for DocuSign."""
+from django import forms
+from django.utils.translation import ugettext_lazy as _
+
+
+class SignerForm(forms.Form):
+    """A form for signer."""
+    name = forms.CharField(
+        label=_("name"),
+        max_length=50,
+    )
+    email = forms.EmailField(
+        label=_("e-mail"),
+    )
+
+
+class PositionedTabForm(forms.Form):
+    """A form for a positioned signing tab (place where signer signs)."""
+    page_number = forms.IntegerField(
+        label=_('page number'),
+        min_value=1,
+    )
+    x_position = forms.IntegerField(
+        label=_('x position'),
+        min_value=0,
+    )
+    y_position = forms.IntegerField(
+        label=_('y position'),
+        min_value=0,
+    )
+
+
+class SignHereTabForm(PositionedTabForm):
+    pass
+
+
+class ApproveTabForm(PositionedTabForm):
+    pass


### PR DESCRIPTION
This is #3 rebased on master + changed the way signature tabs are computed.
In #3, DocuSignBackend accepts an optional dictionary of tabs. One problem is that there are 2 formats: one for the "tabs" dictionary, one for pydocusign's models (such as pydocusign.models.SignHereTab).
In this one, DocuSignBackend uses an internal `get_docusign_tabs(signer)` method that returns a list of suitable pydocusign tab model for signer. Default implementation returns empty list, i.e. the signer will manually choose and place the tab.
